### PR TITLE
ceate setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='parasbolv',
 
       author='Thomas E. Gorochowski, Charlie Clark',
 
-      author_email='tom@chofski.co.uk, charlieclark1.e.e.2019@bristol.ac.uk>',
+      author_email='tom@chofski.co.uk, charlieclark1.e.e.2019@bristol.ac.uk',
 
       url='https://github.com/BiocomputeLab/paraSBOLv/blob/master/parasbolv/parasbolv.py',
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+from distutils.core import setup
+
+setup(name='parasbolv',
+
+      version='0.1.0',
+
+      description='A lightweight Python library designed to simplify the rendering of ' +
+                  'highly-customisable SBOL Visual glyphs and diagrams',
+
+      author='Thomas E. Gorochowski, Charlie Clark',
+
+      author_email='tom@chofski.co.uk, charlieclark1.e.e.2019@bristol.ac.uk>',
+
+      url='https://github.com/BiocomputeLab/paraSBOLv/blob/master/parasbolv/parasbolv.py',
+
+      packages=['parasbolv'],
+
+      requires=[
+          'numpy',
+          'matplotlib'
+      ]
+      )


### PR DESCRIPTION
This allows the package to be installed with `python setup.py install` (or, after publishing to pypi, `pip install parasbolv`), and then imported from a Python script in any directory.